### PR TITLE
edit config/deploy.rb

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,6 +5,7 @@ set :application, 'freemarket_sample_56a'
 set :repo_url, 'git@github.com:fumito-2310/freemarket_sample_56a.git'
 
 set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'vendor/bundle', 'public/system', 'public/uploads')
+set :linked_files, %w{ config/secrets.yml }
 
 set :rbenv_type, :user
 set :rbenv_ruby, '2.5.1'
@@ -22,6 +23,18 @@ namespace :deploy do
   task :restart do
     invoke 'unicorn:restart'
   end
+
+  desc 'upload secrets.yml'
+  task :upload do
+    on roles(:app) do |host|
+      if test "[ ! -d #{shared_path}/config ]"
+        execute "mkdir -p #{shared_path}/config"
+      end
+      upload!('config/secrets.yml', "#{shared_path}/config/secrets.yml")
+    end
+  end
+  before :starting, 'deploy:upload'
+  after :finishing, 'deploy:cleanup'
 end
 
 # Default branch is :master


### PR DESCRIPTION
# What
config/deploy.rb を編集。

# Why
secrets.yml を GitHub を経由せずにデプロイ（アップロード）できるようにするため。