### PR TITLE
Automatic deployment4

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,12 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth, if: :production?
   protect_from_forgery with: :exception
-  before_action :basic_auth
 
   private
+
+  def production?
+    Rails.env.production?
+  end
 
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -18,6 +18,15 @@ set :unicorn_pid, -> { "#{shared_path}/tmp/pids/unicorn.pid" }
 set :unicorn_config_path, -> { "#{current_path}/config/unicorn.rb" }
 set :keep_releases, 5
 
+set :default_env, {
+  rbenv_root: "/usr/local/rbenv",
+  path: "/usr/local/rbenv/shims:/usr/local/rbenv/bin:$PATH",
+  BASIC_AUTH_USER: ENV["BASIC_AUTH_USER"],
+  BASIC_AUTH_PASSWORD: ENV["BASIC_AUTH_PASSWORD"],
+  # AWS_ACCESS_KEY_ID: ENV["AWS_ACCESS_KEY_ID"],
+  # AWS_SECRET_ACCESS_KEY: ENV["AWS_SECRET_ACCESS_KEY"]
+}
+
 after 'deploy:publishing', 'deploy:restart'
 namespace :deploy do
   task :restart do

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -61,3 +61,6 @@
 #   }
 
 server '52.198.219.180', user: 'ec2-user', roles: %w{app db web}
+
+set :rails_env, "production"
+set :unicorn_rack_env, "production"


### PR DESCRIPTION
# What
Basic 認証を、実行環境のみで起動させるための実装

# Why
開発環境で Basic 認証がいちいち起動すると煩雑なため。