### PR TITLE
edit columns in items table

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@
 |delivery_area|string|null: false|
 |delivery_days|string|null: false|
 |price|integer|null: false|
-|user_id|references|null: false, foreign_key: true|
+|seller_id|integer|null: false, foreign_key: true|
+|buyer_id|integer|null: false, foreign_key: true|
 ### Association
 <!-- - has_many :items_categorys
 - has_many :categorys, through: :items_categorys -->

--- a/db/migrate/20191026040314_drop_items.rb
+++ b/db/migrate/20191026040314_drop_items.rb
@@ -1,0 +1,5 @@
+class DropItems < ActiveRecord::Migration[5.0]
+  def change
+    drop_table :items
+  end
+end

--- a/db/migrate/20191026041318_create_items.rb
+++ b/db/migrate/20191026041318_create_items.rb
@@ -4,7 +4,10 @@ class CreateItems < ActiveRecord::Migration[5.0]
       t.string :image, null: false
       t.string :name, null: false
       t.text :explanation, null: false
-      t.string :details_category, null: false
+      t.string :details_category_major, null: false
+      t.string :details_category_medium, null: false
+      t.string :details_category_minor, null: false
+      t.string :details_size, null: false
       t.string :details_state, null: false
       t.string :delivery_fee, null: false
       t.string :delivery_area, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191022053624) do
+ActiveRecord::Schema.define(version: 20191026041318) do
 
   create_table "cards", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id",           null: false
@@ -23,19 +23,22 @@ ActiveRecord::Schema.define(version: 20191022053624) do
   end
 
   create_table "items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "image",                          null: false
-    t.string   "name",                           null: false
-    t.text     "explanation",      limit: 65535, null: false
-    t.string   "details_category",               null: false
-    t.string   "details_state",                  null: false
-    t.string   "delivery_fee",                   null: false
-    t.string   "delivery_area",                  null: false
-    t.string   "delivery_days",                  null: false
-    t.integer  "price",                          null: false
-    t.integer  "seller_id",                      null: false
-    t.integer  "buyer_id",                       null: false
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
+    t.string   "image",                                 null: false
+    t.string   "name",                                  null: false
+    t.text     "explanation",             limit: 65535, null: false
+    t.string   "details_category_major",                null: false
+    t.string   "details_category_medium",               null: false
+    t.string   "details_category_minor",                null: false
+    t.string   "details_size",                          null: false
+    t.string   "details_state",                         null: false
+    t.string   "delivery_fee",                          null: false
+    t.string   "delivery_area",                         null: false
+    t.string   "delivery_days",                         null: false
+    t.integer  "price",                                 null: false
+    t.integer  "seller_id",                             null: false
+    t.integer  "buyer_id",                              null: false
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
   end
 
   create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|


### PR DESCRIPTION
# What
itemsテーブルにおいてカラムを追加（カテゴリーの３段階化、サイズ）
seller_id, buyer_idをカラムに設定することに対応して、ReadMeを改訂

# Why
仕様に合わせるため
